### PR TITLE
feat: add Gemini embedding provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Memory (LanceDB)
 
-Long-term memory plugin for [OpenClaw](https://github.com/openclaw/openclaw) using LanceDB for vector storage and OpenAI for embeddings. Gives your AI assistant persistent memory across conversations with automatic recall and capture.
+Long-term memory plugin for [OpenClaw](https://github.com/openclaw/openclaw) using LanceDB for vector storage and OpenAI or Gemini embeddings. Gives your AI assistant persistent memory across conversations with automatic recall and capture.
 
 ## Features
 
@@ -33,7 +33,9 @@ Add to your `~/.openclaw/openclaw.json`:
         "enabled": true,
         "config": {
           "embedding": {
-            "apiKey": "${OPENAI_API_KEY}"
+            "provider": "openai",
+            "apiKey": "${OPENAI_API_KEY}",
+            "model": "text-embedding-3-small"
           },
           "autoRecall": true,
           "autoCapture": true
@@ -46,12 +48,36 @@ Add to your `~/.openclaw/openclaw.json`:
 
 Set `plugins.slots.memory` to `"memory-lancedb"` to switch from the default `memory-core` plugin. Only one memory plugin can be active at a time.
 
+### Gemini Configuration Example
+
+```json
+{
+  "plugins": {
+    "slots": { "memory": "memory-lancedb" },
+    "entries": {
+      "memory-lancedb": {
+        "config": {
+          "embedding": {
+            "provider": "gemini",
+            "apiKey": "${GEMINI_API_KEY}",
+            "model": "text-embedding-004"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Gemini embeddings are a great low-cost option and come with a generous free tier for many workloads.
+
 ### Config Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `embedding.apiKey` | string | *required* | OpenAI API key (supports `${ENV_VAR}` syntax) |
-| `embedding.model` | string | `text-embedding-3-small` | Embedding model (`text-embedding-3-small` or `text-embedding-3-large`) |
+| `embedding.provider` | string | `openai` | Embedding provider (`openai` or `gemini`) |
+| `embedding.apiKey` | string | *required* | Provider API key (supports `${ENV_VAR}` syntax) |
+| `embedding.model` | string | provider-dependent | OpenAI: `text-embedding-3-small`, `text-embedding-3-large`. Gemini: `text-embedding-004`, `embedding-001` |
 | `dbPath` | string | `~/.openclaw/memory/lancedb` | LanceDB database path |
 | `autoRecall` | boolean | `true` | Inject relevant memories before each response |
 | `autoCapture` | boolean | `false` | Auto-store important user messages |
@@ -63,7 +89,7 @@ Set `plugins.slots.memory` to `"memory-lancedb"` to switch from the default `mem
 
 Before every agent response, the plugin:
 
-1. Embeds the user's message using OpenAI
+1. Embeds the user's message using the configured embedding provider
 2. Searches LanceDB for the top 3 most relevant memories (minimum 0.3 similarity)
 3. Injects them into the system prompt as `<relevant-memories>` context marked as untrusted
 
@@ -126,7 +152,7 @@ Memories are injected as untrusted historical context:
 
 ## Limitations
 
-- **OpenAI-only embeddings** -- requires an OpenAI API key for `text-embedding-3-small` or `text-embedding-3-large`
+- **Embedding providers** -- supports OpenAI (`text-embedding-3-small`, `text-embedding-3-large`) and Gemini (`text-embedding-004`, `embedding-001`)
 - **LanceDB native binaries** -- LanceDB requires native binaries that may not be available on all platforms (notably macOS ARM can have issues)
 
 ## Testing

--- a/config.ts
+++ b/config.ts
@@ -2,9 +2,11 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+export type EmbeddingProvider = "openai" | "gemini";
+
 export type MemoryConfig = {
   embedding: {
-    provider: "openai";
+    provider: EmbeddingProvider;
     model?: string;
     apiKey: string;
   };
@@ -17,7 +19,11 @@ export type MemoryConfig = {
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
-const DEFAULT_MODEL = "text-embedding-3-small";
+const DEFAULT_PROVIDER: EmbeddingProvider = "openai";
+const DEFAULT_MODEL_BY_PROVIDER: Record<EmbeddingProvider, string> = {
+  openai: "text-embedding-3-small",
+  gemini: "text-embedding-004",
+};
 export const DEFAULT_CAPTURE_MAX_CHARS = 500;
 const LEGACY_STATE_DIRS: string[] = [];
 
@@ -48,9 +54,15 @@ function resolveDefaultDbPath(): string {
 
 const DEFAULT_DB_PATH = resolveDefaultDbPath();
 
-const EMBEDDING_DIMENSIONS: Record<string, number> = {
-  "text-embedding-3-small": 1536,
-  "text-embedding-3-large": 3072,
+const EMBEDDING_DIMENSIONS: Record<EmbeddingProvider, Record<string, number>> = {
+  openai: {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+  },
+  gemini: {
+    "text-embedding-004": 768,
+    "embedding-001": 768,
+  },
 };
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
@@ -61,10 +73,15 @@ function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], la
   throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
 }
 
-export function vectorDimsForModel(model: string): number {
-  const dims = EMBEDDING_DIMENSIONS[model];
+export function vectorDimsForModel(provider: EmbeddingProvider, model: string): number {
+  const providerModels = EMBEDDING_DIMENSIONS[provider];
+  if (!providerModels) {
+    throw new Error(`Unsupported embedding provider: ${provider}`);
+  }
+
+  const dims = providerModels[model];
   if (!dims) {
-    throw new Error(`Unsupported embedding model: ${model}`);
+    throw new Error(`Unsupported ${provider} embedding model: ${model}`);
   }
   return dims;
 }
@@ -79,9 +96,10 @@ function resolveEnvVars(value: string): string {
   });
 }
 
-function resolveEmbeddingModel(embedding: Record<string, unknown>): string {
-  const model = typeof embedding.model === "string" ? embedding.model : DEFAULT_MODEL;
-  vectorDimsForModel(model);
+function resolveEmbeddingModel(provider: EmbeddingProvider, embedding: Record<string, unknown>): string {
+  const model =
+    typeof embedding.model === "string" ? embedding.model : DEFAULT_MODEL_BY_PROVIDER[provider];
+  vectorDimsForModel(provider, model);
   return model;
 }
 
@@ -101,9 +119,15 @@ export const memoryConfigSchema = {
     if (!embedding || typeof embedding.apiKey !== "string") {
       throw new Error("embedding.apiKey is required");
     }
-    assertAllowedKeys(embedding, ["apiKey", "model"], "embedding config");
+    assertAllowedKeys(embedding, ["provider", "apiKey", "model"], "embedding config");
 
-    const model = resolveEmbeddingModel(embedding);
+    const provider = embedding.provider;
+    if (provider !== undefined && provider !== "openai" && provider !== "gemini") {
+      throw new Error(`Unsupported embedding provider: ${String(provider)}`);
+    }
+
+    const resolvedProvider = (provider as EmbeddingProvider | undefined) ?? DEFAULT_PROVIDER;
+    const model = resolveEmbeddingModel(resolvedProvider, embedding);
 
     const captureMaxChars =
       typeof cfg.captureMaxChars === "number" ? Math.floor(cfg.captureMaxChars) : undefined;
@@ -116,7 +140,7 @@ export const memoryConfigSchema = {
 
     return {
       embedding: {
-        provider: "openai",
+        provider: resolvedProvider,
         model,
         apiKey: resolveEnvVars(embedding.apiKey),
       },
@@ -127,16 +151,21 @@ export const memoryConfigSchema = {
     };
   },
   uiHints: {
+    "embedding.provider": {
+      label: "Embedding Provider",
+      placeholder: DEFAULT_PROVIDER,
+      help: "Embedding provider to use: openai or gemini",
+    },
     "embedding.apiKey": {
-      label: "OpenAI API Key",
+      label: "Embedding API Key",
       sensitive: true,
-      placeholder: "sk-proj-...",
-      help: "API key for OpenAI embeddings (or use ${OPENAI_API_KEY})",
+      placeholder: "${OPENAI_API_KEY} or ${GEMINI_API_KEY}",
+      help: "API key for the selected embedding provider",
     },
     "embedding.model": {
       label: "Embedding Model",
-      placeholder: DEFAULT_MODEL,
-      help: "OpenAI embedding model to use",
+      placeholder: DEFAULT_MODEL_BY_PROVIDER.openai,
+      help: "Model to use (OpenAI: text-embedding-3-small/large, Gemini: text-embedding-004/embedding-001)",
     },
     dbPath: {
       label: "Database Path",

--- a/index.test.ts
+++ b/index.test.ts
@@ -82,6 +82,49 @@ describe("memory plugin e2e", () => {
     delete process.env.TEST_MEMORY_API_KEY;
   });
 
+  test("config schema parses valid Gemini config", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: {
+        provider: "gemini",
+        apiKey: "gemini-test-key",
+        model: "text-embedding-004",
+      },
+      dbPath,
+    });
+
+    expect(config?.embedding?.provider).toBe("gemini");
+    expect(config?.embedding?.model).toBe("text-embedding-004");
+  });
+
+  test("config schema defaults provider to openai", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: {
+        apiKey: OPENAI_API_KEY,
+      },
+      dbPath,
+    });
+
+    expect(config?.embedding?.provider).toBe("openai");
+  });
+
+  test("config schema rejects unknown provider", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    expect(() => {
+      memoryPlugin.configSchema?.parse?.({
+        embedding: {
+          provider: "unknown",
+          apiKey: OPENAI_API_KEY,
+        },
+        dbPath,
+      });
+    }).toThrow("Unsupported embedding provider: unknown");
+  });
+
   test("config schema rejects missing apiKey", async () => {
     const { default: memoryPlugin } = await import("./index.js");
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     ]
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@lancedb/lancedb": "^0.26.2",
     "@sinclair/typebox": "0.34.48",
     "openai": "^6.22.0"
@@ -41,6 +42,6 @@
     "openclaw": ">=2026.1.26"
   },
   "devDependencies": {
-    "openclaw": "2026.2.20"
+    "openclaw": "2026.2.24"
   }
 }


### PR DESCRIPTION
## What

Adds Google Gemini as an embedding provider alongside the existing OpenAI provider.

## Why

Gemini offers a generous free tier (1,500+ embedding requests/day) making it a zero-cost alternative to OpenAI for memory embeddings. Many OpenClaw users authenticate via Codex OAuth which doesn't cover OpenAI's embedding API — Gemini fills that gap perfectly.

## Changes

- **`config.ts`**: Added `EmbeddingProvider` type (`"openai" | "gemini"`), per-provider model dimensions and defaults, updated config parsing to accept `embedding.provider` field
- **`index.ts`**: Introduced `EmbeddingProvider` interface with `OpenAIEmbeddings` and `GeminiEmbeddings` implementations, factory function `createEmbeddingProvider()` selects the right backend
- **`index.test.ts`**: Added tests for Gemini config parsing, model validation, and unknown provider rejection
- **`package.json`**: Added `@google/generative-ai` dependency
- **`README.md`**: Added Gemini configuration example and supported models

## Backwards compatible

Existing OpenAI configs work unchanged — `provider` defaults to `"openai"` when not specified.

## Supported Gemini models

| Model | Dimensions |
|-------|-----------|
| `text-embedding-004` | 768 |
| `embedding-001` | 768 |

## Usage

```json
{
  "plugins": {
    "slots": { "memory": "memory-lancedb" },
    "entries": {
      "memory-lancedb": {
        "config": {
          "embedding": {
            "provider": "gemini",
            "apiKey": "${GEMINI_API_KEY}",
            "model": "text-embedding-004"
          }
        }
      }
    }
  }
}
```

Get a free API key at [Google AI Studio](https://aistudio.google.com/apikey).