### PR TITLE
docs: add TweetClaw source-memory workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ Memories are injected as untrusted historical context:
 - Prompt injection patterns are detected and rejected during capture
 - Memory IDs are UUID-validated before deletion to prevent query injection
 
+## Optional X/Twitter Source Workflows
+
+When an OpenClaw agent uses public X/Twitter data as research input, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside this memory plugin and store only reviewed notes:
+
+```sh
+openclaw plugins install @xquik/tweetclaw@latest
+```
+
+Use TweetClaw to scrape tweets, search tweets, search tweet replies, export followers, perform user lookup, work with media, monitor tweets, receive webhooks, run giveaway draws, and handle approval-gated post tweets or post tweet replies. Then save durable summaries with `memory_store`, including source URLs, tweet IDs, author handles, capture dates, decisions, and next actions.
+
+Do not store raw exports, secrets, cookies, DMs, or private account material in long-term memory.
+
 ## Limitations
 
 - **Embedding providers** -- supports OpenAI API key mode, OpenAI Codex OAuth mode, and Gemini

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Memories are injected as untrusted historical context:
 When an OpenClaw agent uses public X/Twitter data as research input, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside this memory plugin and store only reviewed notes:
 
 ```sh
-openclaw plugins install @xquik/tweetclaw@latest
+openclaw plugins install @xquik/tweetclaw
 ```
 
 Use TweetClaw to scrape tweets, search tweets, search tweet replies, export followers, perform user lookup, work with media, monitor tweets, receive webhooks, run giveaway draws, and handle approval-gated post tweets or post tweet replies. Then save durable summaries with `memory_store`, including source URLs, tweet IDs, author handles, capture dates, decisions, and next actions.


### PR DESCRIPTION
## Summary

- Add an optional TweetClaw section for OpenClaw agents that use public X/Twitter data as research input.
- Keep LanceDB memory focused on reviewed notes with source URLs, tweet IDs, author handles, capture dates, decisions, and next actions.
- Warn against storing raw exports, secrets, cookies, DMs, or private account material in long-term memory.

## Validation

- Whitespace diff check passed.
- README link sweep checked 2 external URLs with 0 failures.
- TweetClaw GitHub returned 200.
- `npm view @xquik/tweetclaw version` returned `1.6.31`.
- Dependencies installed without lifecycle scripts, audit, funding, or lockfile writes because the repo has no lockfile.
- `npx vitest run` passed with 18 tests and 1 skipped test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Optional X/Twitter Source Workflows" section describing how to pair the memory plugin with TweetClaw for public research inputs. Includes installation steps, a workflow overview, guidance to store durable summaries with metadata (source URLs, tweet IDs, author handles, capture dates, decisions, next actions), and explicit instructions to avoid storing raw exports, secrets, cookies, DMs, or private account material.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noncelogic/openclaw-memory-lancedb/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->